### PR TITLE
Fix Disparate signatures of Post-extending classes

### DIFF
--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -18,6 +18,9 @@ class Attachment extends Post {
 	 * @param bool  $canonical_id Use an existing canonical ID.
 	 * @param array $post_meta    Metadata to assign to the post.
 	 * @param array $options      Additional data about the post.
+	 *   Args
+	 *     - string path                  The local dir path or remote url of the file.
+	 *     - bool   force_update_existing Whether or not to update existing object.
 	 * @return array|int|object|\WP_Error
 	 */
 	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $options = [] ) {

--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -15,9 +15,9 @@ class Attachment extends Post {
 	 *
 	 *
 	 * @param array $post_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
-	 * @param bool  $canonical_id
+	 * @param bool  $canonical_id Use an existing canonical ID.
 	 * @param array $post_meta    Metadata to assign to the post.
-	 * @param array $options       Additional
+	 * @param array $options      Additional data about the post.
 	 * @return array|int|object|\WP_Error
 	 */
 	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $options = [] ) {

--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -197,6 +197,30 @@ class Attachment extends Post {
 	}
 
 	/**
+	 * Get post ID from canonical ID
+	 *
+	 * @param $canonical_id
+	 * @param string $post_type
+	 * @return null|string
+	 */
+	static function get_id_from_canonical_id( $canonical_id, $post_type = 'attachment' ) {
+
+		return parent::get_id_from_canonical_id( $canonical_id, $post_type );
+	}
+
+	/**
+	 * Set canonical ID meta
+	 *
+	 * @param $id
+	 * @param $canonical_id
+	 * @param string $post_type
+	 */
+	static function set_canonical_id( $id, $canonical_id, $post_type = 'attachment' ) {
+
+		parent::set_canonical_id( $id, $canonical_id, $post_type );
+	}
+
+	/**
 	 * Set import path meta
 	 *
 	 * @param $id

--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -13,18 +13,16 @@ class Attachment extends Post {
 	/**
 	 * Upload and add attachment object into the database
 	 *
-	 * @param array $path
-	 * @param array $post_data
-	 * @param bool $canonical_id
-	 * @param array $post_meta
-	 * @param null $file_type_override
-	 * @param bool $force_update_existing
+	 *
+	 * @param array $post_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
+	 * @param bool  $canonical_id
+	 * @param array $post_meta    Metadata to assign to the post.
+	 * @param array $options       Additional
 	 * @return array|int|object|\WP_Error
 	 */
-	static function insert( $path, $post_data = array(), $canonical_id = false, $post_meta = array(), $file_type_override = null, $force_update_existing = true ) {
-
+	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $options = [] ) {
 		$post_parent = isset( $post_data['post_parent'] ) ? $post_data['post_parent'] : 0;
-		$is_url      = filter_var( $path, FILTER_VALIDATE_URL );
+		$is_url      = filter_var( $options['path'], FILTER_VALIDATE_URL );
 
 		if ( empty( $post_data['ID'] ) && $canonical_id && $current_id = static::get_id_from_canonical_id( $canonical_id ) ) {
 			$post_data['ID'] = $current_id;
@@ -32,7 +30,7 @@ class Attachment extends Post {
 
         if ( ! empty( $post_data['ID'] ) ) {
 
-	        if ( $force_update_existing === true ) {
+	        if ( $options['force_update_existing'] === true ) {
 
 		        $post_id = wp_update_post( $post_data, true );
 
@@ -40,7 +38,7 @@ class Attachment extends Post {
 			        static::set_meta( $post_id, $post_meta );
 		        }
 
-		        static::set_import_path_meta( $post_data['ID'], $path );
+		        static::set_import_path_meta( $post_data['ID'], $options['path'] );
 	        }
 
 			return (int) $post_data['ID'];
@@ -48,7 +46,7 @@ class Attachment extends Post {
 
 		static::require_dependencies();
 
-		$file_array = static::prepare_file( $path, $is_url );
+		$file_array = static::prepare_file( $options['path'], $is_url );
 
 		if ( is_wp_error( $file_array ) ) {
 			return $file_array;
@@ -70,7 +68,7 @@ class Attachment extends Post {
 			static::set_canonical_id( $post_id, $canonical_id );
 		}
 
-		static::set_import_path_meta( $post_id, $path );
+		static::set_import_path_meta( $post_id, $options['path'] );
 
 		if ( $post_meta && is_array( $post_meta ) ) {
 			static::set_meta( $post_id, $post_meta );

--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -65,7 +65,7 @@ class Attachment extends Post {
 		}
 
 		if ( $canonical_id ) {
-			static::set_canonical_id( $post_id, $canonical_id );
+			static::set_canonical_id( $post_id, $canonical_id, 'attachment' );
 		}
 
 		static::set_import_path_meta( $post_id, $options['path'] );
@@ -165,34 +165,13 @@ class Attachment extends Post {
 	/**
 	 * Check if attachment exists in the database
 	 *
-	 * @param $canonical_id
+	 * @param mixed  $canonical_id
+	 * @param string $post_type
 	 * @return bool
 	 */
-	static function exists( $canonical_id ) {
+	static function exists( $canonical_id, $post_type = 'attachment' ) {
 
-		return (bool) static::get_id_from_canonical_id( $canonical_id );
-	}
-
-	/**
-	 * Get attachment from canonical ID if it exists in the database
-	 *
-	 * @param $canonical_id
-	 * @return null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id  ) {
-
-		return parent::get_id_from_canonical_id( $canonical_id, 'attachment' );
-	}
-
-	/**
-	 * Set attachment canonical ID meta
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 */
-	static function set_canonical_id( $id, $canonical_id ) {
-
-		parent::set_canonical_id( $id, $canonical_id, 'attachment' );
+		return (bool) static::get_id_from_canonical_id( $canonical_id, $post_type );
 	}
 
 	/**

--- a/inc/classes/inserter/wp/attachment.php
+++ b/inc/classes/inserter/wp/attachment.php
@@ -81,6 +81,25 @@ class Attachment extends Post {
 	}
 
 	/**
+	 * Upload and add attachment object into the database using a path.
+	 *
+	 * @param string $path         The local dir path or remote url of the file.
+	 * @param array  $post_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
+	 * @param bool   $canonical_id Use an existing canonical ID.
+	 * @param array  $post_meta    Metadata to assign to the post.
+	 * @param array  $options      Additional data about the post.
+	 *   Args
+	 *     - bool   force_update_existing Whether or not to update existing object.
+	 * @return array|int|object|\WP_Error
+	 */
+	public static function insert_from_path( $path, $post_data = [], $canonical_id = false, $post_meta = [], $options = []  ) {
+		// Ensure our path value is set appropriately.
+		$options['path'] = $path;
+
+		return static::insert( $post_data, $canonical_id, $post_meta, $options );
+	}
+
+	/**
 	 * Ensure files required for managing media uploads are included
 	 */
 	protected static function require_dependencies() {

--- a/inc/classes/inserter/wp/guest-author.php
+++ b/inc/classes/inserter/wp/guest-author.php
@@ -12,12 +12,13 @@ class Guest_Author extends Post {
 	/**
 	 * Add guest author (post) object into the database
 	 *
-	 * @param array $user_data
-	 * @param bool $canonical_id
-	 * @param array $author_meta
-	 * @return null|string|\WP_Error
+	 * @param array $user_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
+	 * @param bool  $canonical_id
+	 * @param array $author_meta  Metadata to assign to the guest author.
+	 * @param array $options      Optional. Additional
+	 * @return int|string|\WP_Error
 	 */
-	static function insert( $user_data = array(), $canonical_id = false, $author_meta = array() ) {
+	static function insert( $user_data = [], $canonical_id = false, $author_meta = [], $options = [] ) {
 
 		if ( $canonical_id && $current_id = static::get_id_from_canonical_id( $canonical_id, 'guest-author' ) ) {
 			return $current_id;

--- a/inc/classes/inserter/wp/guest-author.php
+++ b/inc/classes/inserter/wp/guest-author.php
@@ -20,7 +20,7 @@ class Guest_Author extends Post {
 	 */
 	static function insert( $user_data = [], $canonical_id = false, $author_meta = [], $options = [] ) {
 
-		if ( $canonical_id && $current_id = static::get_id_from_canonical_id( $canonical_id, 'guest-author' ) ) {
+		if ( $canonical_id && $current_id = static::get_id_from_canonical_id( $canonical_id ) ) {
 			return $current_id;
 		}
 
@@ -146,6 +146,30 @@ class Guest_Author extends Post {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get post ID from canonical ID
+	 *
+	 * @param $canonical_id
+	 * @param string $post_type
+	 * @return null|string
+	 */
+	static function get_id_from_canonical_id( $canonical_id, $post_type = 'guest-author' ) {
+
+		return parent::get_id_from_canonical_id( $canonical_id, $post_type );
+	}
+
+	/**
+	 * Set canonical ID meta
+	 *
+	 * @param $id
+	 * @param $canonical_id
+	 * @param string $post_type
+	 */
+	static function set_canonical_id( $id, $canonical_id, $post_type = 'guest-author' ) {
+
+		parent::set_canonical_id( $id, $canonical_id, $post_type );
 	}
 
 }

--- a/inc/classes/inserter/wp/guest-author.php
+++ b/inc/classes/inserter/wp/guest-author.php
@@ -13,9 +13,9 @@ class Guest_Author extends Post {
 	 * Add guest author (post) object into the database
 	 *
 	 * @param array $user_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
-	 * @param bool  $canonical_id
-	 * @param array $author_meta  Metadata to assign to the guest author.
-	 * @param array $options      Optional. Additional
+	 * @param bool  $canonical_id Use an existing canonical ID.
+	 * @param array $author_meta  Metadata to assign to the post.
+	 * @param array $options      Additional data about the post.
 	 * @return int|string|\WP_Error
 	 */
 	static function insert( $user_data = [], $canonical_id = false, $author_meta = [], $options = [] ) {

--- a/inc/classes/inserter/wp/post.php
+++ b/inc/classes/inserter/wp/post.php
@@ -13,9 +13,9 @@ class Post extends Base {
 	 * Add post object to the database
 	 *
 	 * @param array $post_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
-	 * @param bool  $canonical_id
+	 * @param bool  $canonical_id Use an existing canonical ID.
 	 * @param array $post_meta    Metadata to assign to the post.
-	 * @param array $options      Optional. Additional
+	 * @param array $options      Additional data about the post.
 	 * @return int|\WP_Error
 	 */
 	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $options = [] ) {

--- a/inc/classes/inserter/wp/post.php
+++ b/inc/classes/inserter/wp/post.php
@@ -12,12 +12,13 @@ class Post extends Base {
 	/**
 	 * Add post object to the database
 	 *
-	 * @param array $post_data
-	 * @param bool $canonical_id
-	 * @param array $post_meta
+	 * @param array $post_data    Post data formatted as it will be saved to the posts table. Should match WP_Post data.
+	 * @param bool  $canonical_id
+	 * @param array $post_meta    Metadata to assign to the post.
+	 * @param array $options      Optional. Additional
 	 * @return int|\WP_Error
 	 */
-	static function insert( $post_data = array(), $canonical_id = false, $post_meta = array() ) {
+	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $options = [] ) {
 
 		if ( empty( $post_data['post_type'] ) ) {
 			$post_data['post_type'] = 'post';

--- a/inc/classes/inserter/wp/post.php
+++ b/inc/classes/inserter/wp/post.php
@@ -71,7 +71,7 @@ class Post extends Base {
 	/**
 	 * Check if post exists with provided canonical ID
 	 *
-	 * @param $canonical_id
+	 * @param mixed  $canonical_id
 	 * @param string $post_type
 	 * @return bool
 	 */


### PR DESCRIPTION
The signatures for several methods on classes extending `HMCI\Inserter\WP\Post` had different signatures which will no longer fly in newer PHP versions. 

This attempts to make the signatures more consistent and reduce some unnecessary redundancies.

Resolves #40