### PR TITLE
Trigger a PHP warning if an importer or validator is added and its class does not exist

### DIFF
--- a/inc/classes/class-master.php
+++ b/inc/classes/class-master.php
@@ -59,6 +59,11 @@ class Master {
 
 		if ( class_exists( $class_name ) ) {
 			self::$importers[ $key ] = $class_name;
+		} else {
+			trigger_error( sprintf(
+				'Importer class not found: "%s"',
+				$class_name
+			), E_USER_WARNING );
 		}
 	}
 
@@ -109,6 +114,11 @@ class Master {
 
 		if ( class_exists( $class_name ) ) {
 			self::$validators[ $key ] = $class_name;
+		} else {
+			trigger_error( sprintf(
+				'Validator class not found: "%s"',
+				$class_name
+			), E_USER_WARNING );
 		}
 	}
 


### PR DESCRIPTION
The following currently fails silently. Let's trigger a PHP warning instead.

```php
Master::add_importer( 'foo', 'Class_That_Does_Not_Exist' );
```