### PR TITLE
Fix an incorrect count for the Files iterator

### DIFF
--- a/inc/classes/iterator/files/class-base.php
+++ b/inc/classes/iterator/files/class-base.php
@@ -49,7 +49,7 @@ abstract class Base extends \HMCI\Iterator\Base {
 
 		$files_in_path = $this->get_files_in_path();
 
-		return is_wp_error( $files_in_path ) ? $files_in_path : count( $files_in_path );
+		return is_wp_error( $files_in_path ) ? $files_in_path : count( $this->filter_files( $files_in_path ) );
 	}
 
 	/**


### PR DESCRIPTION
When running an import, the initial message states:

```
Importing data for foo (X items)
```

The value of `X` isn't accurate for the Files iterator as it doesn't pass the file list through the file filter prior to returning the count. This means that all files in the directory are counted, not just JSON or XML files as appropriate, and on a Unix system this means the `.` and `..` directory pointers are included in the count too.