### PR TITLE
Switch to a recursive directory iterator for the file fetcher

### DIFF
--- a/inc/classes/iterator/files/class-base.php
+++ b/inc/classes/iterator/files/class-base.php
@@ -88,13 +88,14 @@ abstract class Base extends \HMCI\Iterator\Base {
 		}
 
 		if ( is_dir( $path_found ) ) {
+			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path_found ) );
+			$files    = [];
 
-			$files = array_map( function( $item ) use ( $path_found ) {
-
-				return $path_found . '/' . $item;
-
-			}, scandir( $path_found ) );
-
+			foreach ( $iterator as $pointer ) {
+				if ( ! $pointer->isDir() ) {
+					$files[] = $pointer->getPathname();
+				}
+			}
 		} else {
 
 			$files = [ $path_found ];


### PR DESCRIPTION
Switching to the recursive directory iterator has a few benefits:

* Exports can be sub-divided into sub-directories for increased filesystem performance (directories which contain a large number of files are slower to read and less manageable). We're planning on doing this for RS.
* PHP's filesystem iterators ignore dot files by default (unlike `scandir()`), which means the file filters don't necessary need to worry about them.
* Using iterators allow us to switch to using generators (with `yield`) in the future for better memory management.