### PR TITLE
57 - Improve meta lookup handling

### DIFF
--- a/inc/classes/class-master.php
+++ b/inc/classes/class-master.php
@@ -2,6 +2,8 @@
 
 namespace HMCI;
 
+use function HM\Meta_Lookups\register_lookup;
+
 /**
  * Singleton master class for HMCI
  *
@@ -44,6 +46,7 @@ class Master {
 		if ( ! static::$instance ) {
 			static::$instance = new static();
 			static::$instance->init_cli();
+			static::$instance->init_lookups();
 		}
 
 		return static::$instance;
@@ -151,12 +154,25 @@ class Master {
 
 	/**
 	 * Initialise WP CLI command
-	 *
 	 */
-	protected static function init_cli() {
+	protected function init_cli() {
 
 		if ( defined( 'WP_CLI' ) && 'WP_CLI' ) {
 			\WP_CLI::add_command( 'hmci',  apply_filters( 'hmci_wp_cli_class_name', __NAMESPACE__ . '\\CLI\\HMCI' ) );
+		}
+	}
+
+	/**
+	 * Init canonical ID lookups for all core object types
+	 */
+	protected function init_lookups() {
+
+		if ( ! is_callable( 'HM\\Meta_Lookups\\register_lookup' ) ) {
+			return;
+		}
+
+		foreach ( [ 'post', 'comment', 'user', 'term' ] as $type ) {
+			register_lookup( sprintf( '%s_%s', CANONICAL_ID_LOOKUP_KEY, $type ), $type, CANONICAL_ID_LOOKUP_KEY );
 		}
 	}
 }

--- a/inc/classes/inserter/class-base.php
+++ b/inc/classes/inserter/class-base.php
@@ -2,6 +2,8 @@
 
 namespace HMCI\Inserter;
 
+use const HMCI\CANONICAL_ID_LOOKUP_KEY;
+
 /**
  *
  * Base inserter class
@@ -18,8 +20,7 @@ abstract class Base implements Base_Interface {
 	 * @return mixed|void
 	 */
 	static function get_canonical_id_key() {
-
-		return apply_filters( 'hmci_import_type_canonical_id_key', 'hmci_canonical_id', get_called_class() );
+		return apply_filters( 'hmci_canonical_id_key', CANONICAL_ID_LOOKUP_KEY, static::class );
 	}
 
 	/**

--- a/inc/classes/inserter/wp/class-attachment.php
+++ b/inc/classes/inserter/wp/class-attachment.php
@@ -68,7 +68,7 @@ class Attachment extends Post {
 		}
 
 		if ( $canonical_id ) {
-			static::set_canonical_id( $post_id, $canonical_id, 'attachment' );
+			static::set_canonical_id( $post_id, $canonical_id );
 		}
 
 		static::set_import_path_meta( $post_id, $options['path'] );
@@ -181,39 +181,6 @@ class Attachment extends Post {
 	 */
 	protected static function cleanup_file( $file_array ) {
 		@unlink( $file_array['tmp_name'] ); //phpcs:ignore
-	}
-
-	/**
-	 * Check if attachment exists in the database
-	 *
-	 * @param mixed  $canonical_id
-	 * @param string $post_type
-	 * @return bool
-	 */
-	static function exists( $canonical_id, $post_type = 'attachment' ) {
-		return (bool) static::get_id_from_canonical_id( $canonical_id, $post_type );
-	}
-
-	/**
-	 * Get post ID from canonical ID
-	 *
-	 * @param $canonical_id
-	 * @param string $post_type
-	 * @return null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id, $post_type = 'attachment' ) {
-		return parent::get_id_from_canonical_id( $canonical_id, $post_type );
-	}
-
-	/**
-	 * Set canonical ID meta
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 * @param string $post_type
-	 */
-	static function set_canonical_id( $id, $canonical_id, $post_type = 'attachment' ) {
-		parent::set_canonical_id( $id, $canonical_id, $post_type );
 	}
 
 	/**

--- a/inc/classes/inserter/wp/class-base-interface.php
+++ b/inc/classes/inserter/wp/class-base-interface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace HMCI\Inserter\WP;
+
+/**
+ * Base WP Inserter class interface
+ *
+ * @package HMCI\Inserter\WP
+ */
+interface Base_Interface {
+
+	/**
+	 * Get the core object type used by the inserter.
+	 *
+	 * @return string
+	 */
+	static function get_core_object_type();
+}

--- a/inc/classes/inserter/wp/class-base.php
+++ b/inc/classes/inserter/wp/class-base.php
@@ -2,9 +2,78 @@
 
 namespace HMCI\Inserter\WP;
 
+use HM\Meta_Lookups\Lookup;
+
 /**
  * Base WP Inserter class
  *
  * @package HMCI\Inserter\WP
  */
-abstract class Base extends \HMCI\Inserter\Base {}
+abstract class Base extends \HMCI\Inserter\Base implements Base_Interface {
+
+	/**
+	 * Set meta data
+	 *
+	 * @param $object_id
+	 * @param $meta_data
+	 */
+	static function set_meta( $object_id, $meta_data ) {
+
+		foreach ( $meta_data as $meta_key => $meta_value ) {
+			if ( is_null( $meta_value ) ) {
+				delete_metadata( static::get_core_object_type(), $object_id, $meta_key );
+			} else {
+				update_metadata( static::get_core_object_type(), $object_id, $meta_key, $meta_value );
+			}
+		}
+	}
+
+	/**
+	 * Check if post exists with provided canonical ID
+	 *
+	 * @param mixed  $canonical_id
+	 * @return bool
+	 */
+	static function exists( $canonical_id ) {
+
+		return (bool) static::get_id_from_canonical_id( $canonical_id );
+	}
+	
+	/**
+	 * Get post ID from canonical ID
+	 *
+	 * @param $canonical_id
+	 * @return null|string
+	 */
+	static function get_id_from_canonical_id( $canonical_id ) {
+
+		$lookup_name = sprintf( '%s_%s', static::get_canonical_id_key(), static::get_core_object_type() );
+
+		// If we have cached meta lookup support, use that.
+		if ( class_exists( 'HM\\Meta_Lookups\\Lookup' ) && Lookup::get_instance( $lookup_name ) ) {
+			return Lookup::get_instance( $lookup_name )->get( $canonical_id );
+		}
+
+		// No cached meta lookup support, do a direct query.
+		global $wpdb;
+
+		$table = $wpdb->{static::get_core_object_type() . 'meta'};
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $table WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key(), $canonical_id ) );
+	}
+
+	/**
+	 * Set canonical ID meta
+	 *
+	 * @param $id
+	 * @param $canonical_id
+	 */
+	static function set_canonical_id( $id, $canonical_id ) {
+
+		if ( ! $canonical_id ) {
+			return;
+		}
+
+		update_metadata( static::get_core_object_type(), $id, static::get_canonical_id_key(), $canonical_id );
+	}
+}

--- a/inc/classes/inserter/wp/class-comment.php
+++ b/inc/classes/inserter/wp/class-comment.php
@@ -26,9 +26,9 @@ class Comment extends Base {
 		}
 
 		if ( ! empty( $comment_data['comment_ID'] ) ) {
-			$comment_id = wp_update_comment( $comment_data, true );
+			$comment_id = wp_update_comment( $comment_data );
 		} else {
-			$comment_id = wp_insert_comment( $comment_data, true );
+			$comment_id = wp_insert_comment( $comment_data );
 		}
 
 		if ( is_wp_error( $comment_id ) ) {
@@ -47,25 +47,6 @@ class Comment extends Base {
 	}
 
 	/**
-	 * Set meta data
-	 *
-	 * @param $comment_id
-	 * @param $meta_data
-	 */
-	static function set_meta( $comment_id, $meta_data ) {
-
-		foreach ( $meta_data as $meta_key => $meta_value ) {
-
-			if ( is_null( $meta_value ) ) {
-				delete_comment_meta( $comment_id, $meta_key );
-			} else {
-				update_comment_meta( $comment_id, $meta_key, $meta_value );
-			}
-		}
-
-	}
-
-	/**
 	 * Check if comment exists with provided canonical ID
 	 *
 	 * @param $canonical_id
@@ -77,34 +58,12 @@ class Comment extends Base {
 	}
 
 	/**
-	 * Get comment ID from canonical ID
+	 * Get the WP core object type used by the inserter.
 	 *
-	 * @param $canonical_id
-	 * @return null|string
+	 * @return string
 	 */
-	static function get_id_from_canonical_id( $canonical_id ) {
+	static function get_core_object_type() {
 
-		$meta_key = sprintf( 'hmci_lookup_%s', md5( $canonical_id ) );
-
-		global $wpdb;
-
-		return $wpdb->get_var( $wpdb->prepare( "SELECT comment_id FROM $wpdb->commentmeta WHERE meta_key = %s", $meta_key ) );
+		return 'comment';
 	}
-
-	/**
-	 * Set canonical ID meta
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 */
-	static function set_canonical_id( $id, $canonical_id ) {
-
-		if ( ! $canonical_id ) {
-			return;
-		}
-
-		update_comment_meta( $id, static::get_canonical_id_key(), $canonical_id );
-		update_comment_meta( $id, sprintf( 'hmci_lookup_%s', md5( $canonical_id ) ), 1 );
-	}
-
 }

--- a/inc/classes/inserter/wp/class-comment.php
+++ b/inc/classes/inserter/wp/class-comment.php
@@ -47,17 +47,6 @@ class Comment extends Base {
 	}
 
 	/**
-	 * Check if comment exists with provided canonical ID
-	 *
-	 * @param $canonical_id
-	 * @return bool
-	 */
-	static function exists( $canonical_id ) {
-
-		return (bool) static::get_id_from_canonical_id( $canonical_id );
-	}
-
-	/**
 	 * Get the WP core object type used by the inserter.
 	 *
 	 * @return string

--- a/inc/classes/inserter/wp/class-guest-author.php
+++ b/inc/classes/inserter/wp/class-guest-author.php
@@ -41,7 +41,7 @@ class Guest_Author extends Post {
 		}
 
 		if ( $canonical_id ) {
-			static::set_canonical_id( $post_id, $canonical_id, 'guest-author' );
+			static::set_canonical_id( $post_id, $canonical_id );
 		}
 
 		if ( $author_meta && is_array( $author_meta ) ) {
@@ -154,29 +154,4 @@ class Guest_Author extends Post {
 
 		return true;
 	}
-
-	/**
-	 * Get post ID from canonical ID
-	 *
-	 * @param $canonical_id
-	 * @param string $post_type
-	 * @return null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id, $post_type = 'guest-author' ) {
-
-		return parent::get_id_from_canonical_id( $canonical_id, $post_type );
-	}
-
-	/**
-	 * Set canonical ID meta
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 * @param string $post_type
-	 */
-	static function set_canonical_id( $id, $canonical_id, $post_type = 'guest-author' ) {
-
-		parent::set_canonical_id( $id, $canonical_id, $post_type );
-	}
-
 }

--- a/inc/classes/inserter/wp/class-post.php
+++ b/inc/classes/inserter/wp/class-post.php
@@ -26,7 +26,7 @@ class Post extends Base {
 
 		if ( empty( $post_data['ID'] ) && $canonical_id ) {
 
-			$current_id = static::get_id_from_canonical_id( $canonical_id, $post_data['post_type'] );
+			$current_id = static::get_id_from_canonical_id( $canonical_id );
 
 			if ( $current_id ) {
 				$post_data['ID'] = $current_id;
@@ -44,7 +44,7 @@ class Post extends Base {
 		}
 
 		if ( $canonical_id ) {
-			static::set_canonical_id( $post_id, $canonical_id, $post_data['post_type'] );
+			static::set_canonical_id( $post_id, $canonical_id );
 		}
 
 		if ( $post_meta && is_array( $post_meta ) ) {
@@ -55,67 +55,12 @@ class Post extends Base {
 	}
 
 	/**
-	 * Set meta data
+	 * Get the WP core object type used by the inserter.
 	 *
-	 * @param $post_id
-	 * @param $meta_data
+	 * @return string
 	 */
-	static function set_meta( $post_id, $meta_data ) {
+	static function get_core_object_type() {
 
-		foreach ( $meta_data as $meta_key => $meta_value ) {
-
-			if ( is_null( $meta_value ) ) {
-				delete_post_meta( $post_id, $meta_key );
-			} else {
-				update_post_meta( $post_id, $meta_key, $meta_value );
-			}
-		}
-
+		return 'post';
 	}
-
-	/**
-	 * Check if post exists with provided canonical ID
-	 *
-	 * @param mixed  $canonical_id
-	 * @param string $post_type
-	 * @return bool
-	 */
-	static function exists( $canonical_id, $post_type = 'post' ) {
-
-		return (bool) static::get_id_from_canonical_id( $canonical_id, $post_type );
-	}
-
-	/**
-	 * Get post ID from canonical ID
-	 *
-	 * @param $canonical_id
-	 * @param string $post_type
-	 * @return null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id, $post_type = 'post' ) {
-
-		$meta_key = sprintf( 'hmci_lookup_%s', md5( $post_type . $canonical_id ) );
-
-		global $wpdb;
-
-		return $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = %s", $meta_key ) );
-	}
-
-	/**
-	 * Set canonical ID meta
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 * @param string $post_type
-	 */
-	static function set_canonical_id( $id, $canonical_id, $post_type = 'post' ) {
-
-		if ( ! $canonical_id ) {
-			return;
-		}
-
-		update_post_meta( $id, static::get_canonical_id_key() . '_' . $post_type, $canonical_id );
-		update_post_meta( $id, sprintf( 'hmci_lookup_%s', md5( $post_type . $canonical_id ) ), 1 );
-	}
-
 }

--- a/inc/classes/inserter/wp/class-term.php
+++ b/inc/classes/inserter/wp/class-term.php
@@ -21,7 +21,7 @@ class Term extends Base {
 	 */
 	static function insert( $term, $taxonomy, $canonical_id = false, $args = [], $term_meta = [] ) {
 
-		$current_id = static::get_id_from_canonical_id( $canonical_id, $taxonomy );
+		$current_id = static::get_id_from_canonical_id( $canonical_id );
 
 		// Got term by canonical ID marker
 		if ( $canonical_id && $current_id ) {
@@ -54,7 +54,7 @@ class Term extends Base {
 
 		// Canonical ID provided, set it
 		if ( $canonical_id ) {
-			static::set_canonical_id( $term_id, $canonical_id, $taxonomy );
+			static::set_canonical_id( $term_id, $canonical_id );
 		}
 
 		// Meta data provided, set it
@@ -66,83 +66,12 @@ class Term extends Base {
 	}
 
 	/**
-	 * Set term meta
+	 * Get the WP core object type used by the inserter.
 	 *
-	 * @param $term_id
-	 * @param $meta_data
+	 * @return string
 	 */
-	static function set_meta( $term_id, $meta_data ) {
+	static function get_core_object_type() {
 
-		if ( ! is_callable( 'delete_term_meta' ) || ! is_callable( 'update_term_meta' ) ) {
-			return;
-		}
-
-		foreach ( $meta_data as $meta_key => $meta_value ) {
-
-			if ( is_null( $meta_value ) ) {
-				delete_term_meta( $term_id, $meta_key );
-			} else {
-				update_term_meta( $term_id, $meta_key, $meta_value );
-			}
-		}
-
+		return 'term';
 	}
-
-	/**
-	 * Check if term exists for provided canonical ID
-	 *
-	 * @param $canonical_id
-	 * @param null $taxonomy
-	 * @return bool
-	 */
-	static function exists( $canonical_id, $taxonomy = null ) {
-
-		return (bool) static::get_id_from_canonical_id( $canonical_id, $taxonomy );
-	}
-
-	/**
-	 * Get term ID from canonical ID
-	 *
-	 * @param $canonical_id
-	 * @param null $taxonomy
-	 * @return bool|null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id, $taxonomy = null ) {
-
-		if ( ! is_callable( 'delete_term_meta' ) || ! is_callable( 'update_term_meta' ) ) {
-			return false;
-		}
-
-		global $wpdb;
-
-		return $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM $wpdb->termmeta WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key_suffixed( $taxonomy ), $canonical_id ) );
-	}
-
-	/**
-	 * Set term canonical ID
-	 *
-	 * @param $id
-	 * @param $canonical_id
-	 * @param null $taxonomy
-	 */
-	static function set_canonical_id( $id, $canonical_id, $taxonomy = null ) {
-
-		if ( ! $canonical_id || ! is_callable( 'update_term_meta' ) ) {
-			return;
-		}
-
-		update_term_meta( $id, static::get_canonical_id_key_suffixed( $taxonomy ), $canonical_id );
-	}
-
-	/**
-	 * Get canonical ID meta key
-	 *
-	 * @param null $taxonomy
-	 * @return mixed|string|void
-	 */
-	static function get_canonical_id_key_suffixed( $taxonomy = null ) {
-
-		return ( $taxonomy ) ? static::get_canonical_id_key() . '_' . $taxonomy : static::get_canonical_id_key();
-	}
-
 }

--- a/inc/classes/inserter/wp/class-user.php
+++ b/inc/classes/inserter/wp/class-user.php
@@ -25,7 +25,7 @@ class User extends Base {
 			$user_data['ID'] = $current_id;
 		}
 
-		$user_id = wp_insert_user( $user_data, true );
+		$user_id = wp_insert_user( $user_data );
 
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;
@@ -40,39 +40,6 @@ class User extends Base {
 		}
 
 		return $user_id;
-	}
-
-	/**
-	 * Set user meta
-	 *
-	 * @param $user_id
-	 * @param $meta_data
-	 */
-	static function set_meta( $user_id, $meta_data ) {
-
-		foreach ( $meta_data as $meta_key => $meta_value ) {
-
-			if ( is_null( $meta_value ) ) {
-				delete_post_meta( $user_id, $meta_key );
-			} else {
-				update_user_meta( $user_id, $meta_key, $meta_value );
-			}
-		}
-
-	}
-
-	/**
-	 * Get user ID from canonical ID
-	 *
-	 *
-	 * @param $canonical_id
-	 * @return null|string
-	 */
-	static function get_id_from_canonical_id( $canonical_id ) {
-
-		global $wpdb;
-
-		return $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key(), $canonical_id ) );
 	}
 
 	/**
@@ -102,18 +69,12 @@ class User extends Base {
 	}
 
 	/**
-	 * Set user canonical ID
+	 * Get the WP core object type used by the inserter.
 	 *
-	 * @param $id
-	 * @param $canonical_id
+	 * @return string
 	 */
-	static function set_canonical_id( $id, $canonical_id ) {
+	static function get_core_object_type() {
 
-		if ( ! $canonical_id ) {
-			return;
-		}
-
-		update_user_meta( $id, static::get_canonical_id_key(), $canonical_id );
+		return 'user';
 	}
-
 }

--- a/plugin.php
+++ b/plugin.php
@@ -35,6 +35,7 @@ require_once( __DIR__ . '/inc/classes/inserter/class-base.php' );
 require_once( __DIR__ . '/inc/classes/inserter/file/class-base.php' );
 require_once( __DIR__ . '/inc/classes/inserter/file/class-csv.php' );
 
+require_once( __DIR__ . '/inc/classes/inserter/wp/class-base-interface.php' );
 require_once( __DIR__ . '/inc/classes/inserter/wp/class-base.php' );
 require_once( __DIR__ . '/inc/classes/inserter/wp/class-post.php' );
 require_once( __DIR__ . '/inc/classes/inserter/wp/class-user.php' );
@@ -45,6 +46,11 @@ require_once( __DIR__ . '/inc/classes/inserter/wp/class-comment.php' );
 
 require_once( __DIR__ . '/inc/classes/class-master.php' );
 
+/**
+ * Meta key where canonical IDs are stored.
+ */
+const CANONICAL_ID_LOOKUP_KEY = 'hmci_canonical_id';
+
 // Only incude CLI command file if WP_CLI is defined
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( __DIR__ . '/inc/classes/cli/class-hmci.php' );
@@ -53,4 +59,4 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 // Initialise the master instance
 add_action( 'init', function() {
 	Master::get_instance();
-} );
+}, 1 );


### PR DESCRIPTION
### Issue #57 

- Remove WP inserter hmci_lookup_% handling, use standard key/val lookup instead
- Consolidate WP inserter meta lookup handling into base WP class, use the same key for all object types by default so we can easily cross-integrate the meta-lookup framework
- Integrate the meta-lookup framework handling for more performance cached meta lookups


**This is a breaking change**
Any projects currently using HMCI with content already imported will need some DB updates to ensure content isn't duplicated on the next import run.

The change includes removal of unique canoncial ID meta keys per post type and per term taxonomy.

Terms and post objects (including attachments) will need canonical meta fields updated

```
// Set the new canonical_id meta key for posts of type post on single site (update table name if multisite)
UPDATE wp_postmeta SET meta_key = 'hmci_canonical_id' WHERE meta_key = 'hmci_canonical_id_post'

// Set the new canonical_id meta key for posts of type attachment on single site (update table name if multisite)
UPDATE wp_postmeta SET meta_key = 'hmci_canonical_id' WHERE meta_key = 'hmci_canonical_id_attachment'

// Remove all hmci_lookup_* meta keys, no longer needed
DELETE from wp_postmeta WHERE meta_key LIKE 'hmci_lookup%'

// Set the new canonical_id meta key for terms of type category on single site (update table name if multisite)
UPDATE wp_termmeta SET meta_key = 'hmci_canonical_id' WHERE meta_key = 'hmci_canonical_id_category'
```
