### PR TITLE
Fix progress tick 

### DIFF
--- a/inc/classes/cli/class-hmci.php
+++ b/inc/classes/cli/class-hmci.php
@@ -77,9 +77,9 @@ class HMCI extends \WP_CLI_Command {
 			$importer->iterate_items( $items );
 			// Only tick if the offset hasn't been changed by the importer
 			if ( $progress->current() === $current_offset ) {
-				$progress->tick( count( $items ) );
+				$progress->tick( $importer->args['items_per_loop'] );
 			}
-			$current_offset += count( $items );
+			$current_offset += $importer->args['items_per_loop'];
 
 			if ( ( $offset + $current_offset ) >= $total ) {
 				break;


### PR DESCRIPTION
> Tick the progress according to the specified items per loop, not the actual item count, which may differ.

@johnbillion I'm not sure if you remember making this change, but we have a project that is tracking a branch, and there are concerns they won't get any other updates. 

If this is a fix for a bug, we should try and get it merged? Unfortunately I don't have much knowledge of this functionality, but I wanted to open a PR to give it some visibility. 