### PR TITLE
Override base method for terms to use correct column in SQL query

### DIFF
--- a/inc/classes/inserter/wp/class-term.php
+++ b/inc/classes/inserter/wp/class-term.php
@@ -74,4 +74,27 @@ class Term extends Base {
 
 		return 'term';
 	}
+
+	/**
+	 * Get term ID from canonical ID
+	 *
+	 * @param $canonical_id
+	 * @return null|string
+	 */
+	static function get_id_from_canonical_id( $canonical_id ) {
+
+		$lookup_name = sprintf( '%s_%s', static::get_canonical_id_key(), static::get_core_object_type() );
+
+		// If we have cached meta lookup support, use that.
+		if ( class_exists( 'HM\\Meta_Lookups\\Lookup' ) && Lookup::get_instance( $lookup_name ) ) {
+			return Lookup::get_instance( $lookup_name )->get( $canonical_id );
+		}
+
+		// No cached meta lookup support, do a direct query.
+		global $wpdb;
+
+		$table = $wpdb->{static::get_core_object_type() . 'meta'};
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM $table WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key(), $canonical_id ) );
+	}
 }


### PR DESCRIPTION
Fixes an error when `get_id_from_canonical_id` is called for a term, and it uses the base class method which uses `post_id` in the SQL query, but this field does not exist for terms

> WordPress database error Unknown column 'post_id' in 'field list' for query SELECT post_id FROM wp_termmeta WHERE meta_key = 'hmci_canonical_id' AND meta_value = '113' made by include('phar:///usr/local/bin/wp/php/boot-phar.php'), include('phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php'), WP_CLI\bootstrap, WP_CLI\Bootstrap\LaunchRunner->process, WP_CLI\Runner->start, WP_CLI\Runner->run_command_and_exit, WP_CLI\Runner->run_command, WP_CLI\Dispatcher\Subcommand->invoke, call_user_func, WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}, call_user_func, HMCI\CLI\HMCI->import, HMCI\Iterator\Base->iterate_items, HMCI\Iterator\Base->iterate_item, Naturvern\ContentImporter\CorePublish_Articles_Importer->process_item, Naturvern\ContentImporter\CorePublish_Articles_Importer->get_category_from_meta, HMCI\Inserter\WP\Base::exists, HMCI\Inserter\WP\Base::get_id_from_canonical_id
