### PR TITLE
Fix canonical lookup for user and term import

### DIFF
--- a/inc/classes/inserter/wp/class-base.php
+++ b/inc/classes/inserter/wp/class-base.php
@@ -38,14 +38,14 @@ abstract class Base extends \HMCI\Inserter\Base implements Base_Interface {
 
 		return (bool) static::get_id_from_canonical_id( $canonical_id );
 	}
-	
+
 	/**
 	 * Get post ID from canonical ID
 	 *
 	 * @param $canonical_id
 	 * @return null|string
 	 */
-	static function get_id_from_canonical_id( $canonical_id ) {
+	static function get_id_from_canonical_id( $canonical_id, $id_field = 'post_id' ) {
 
 		$lookup_name = sprintf( '%s_%s', static::get_canonical_id_key(), static::get_core_object_type() );
 
@@ -59,7 +59,7 @@ abstract class Base extends \HMCI\Inserter\Base implements Base_Interface {
 
 		$table = $wpdb->{static::get_core_object_type() . 'meta'};
 
-		return $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $table WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key(), $canonical_id ) );
+		return $wpdb->get_var( $wpdb->prepare( "SELECT $id_field FROM $table WHERE meta_key = %s AND meta_value = %s", static::get_canonical_id_key(), $canonical_id ) );
 	}
 
 	/**

--- a/inc/classes/inserter/wp/class-term.php
+++ b/inc/classes/inserter/wp/class-term.php
@@ -21,7 +21,7 @@ class Term extends Base {
 	 */
 	static function insert( $term, $taxonomy, $canonical_id = false, $args = [], $term_meta = [] ) {
 
-		$current_id = static::get_id_from_canonical_id( $canonical_id );
+		$current_id = static::get_id_from_canonical_id( $canonical_id, 'term_id' );
 
 		// Got term by canonical ID marker
 		if ( $canonical_id && $current_id ) {

--- a/inc/classes/inserter/wp/class-user.php
+++ b/inc/classes/inserter/wp/class-user.php
@@ -19,7 +19,7 @@ class User extends Base {
 	 */
 	static function insert( $user_data, $canonical_id = false, $user_meta = [] ) {
 
-		$current_id = static::get_id_from_canonical_id( $canonical_id );
+		$current_id = static::get_id_from_canonical_id( $canonical_id, 'user_id' );
 
 		if ( $canonical_id && $current_id ) {
 			$user_data['ID'] = $current_id;


### PR DESCRIPTION
The base `get_id_from_canonical_id` method is querying for a post_id field, which doesn't work with other types of meta. This adds a configurable "id_field" parameter which can be passed into this function so that it can work for users or other data types.