### PR TITLE
Avoid fatal trying to sideload nonexistant images

### DIFF
--- a/inc/classes/inserter/wp/class-attachment.php
+++ b/inc/classes/inserter/wp/class-attachment.php
@@ -132,7 +132,6 @@ class Attachment extends Post {
 
 			// If error storing temporarily, unlink
 			if ( is_wp_error( $file_array['tmp_name'] ) ) {
-				@unlink( $file_array['tmp_name'] ); // phpcs:ignore
 				return $file_array['tmp_name'];
 			}
 


### PR DESCRIPTION
Trying to pass  WP_Error into `unlink` will cause a fatal, even if muting output errors:

	Fatal error: Uncaught TypeError: unlink(): Argument #1
	($filename) must be of type string, WP_Error given in
	/usr/src/app/content/plugins/hm-content-import/inc/classes/inserter/wp/class-attachment.php:135