### PR TITLE
Add WooCommerce inserter classes

### DIFF
--- a/inc/classes/inserter/woocommerce/class-order-item.php
+++ b/inc/classes/inserter/woocommerce/class-order-item.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HMCI\Inserter\Woocommerce;
+
+use HMCI\Inserter\WP\Base;
+
+/**
+ * Woocommerce Order Item inserter - manages inserting order items into the woocommerce_order_items table.
+ *
+ * @package HMCI\Inserter\WP
+ */
+class Order_Item extends Base {
+
+	static function insert( $order_item, $canonical_id = false, $order_item_meta = [] ) {
+
+		if ( empty( $order_item['order_item_id'] ) && $canonical_id ) {
+			$current_id = static::get_id_from_canonical_id( $canonical_id, 'order_item_id' );
+
+			if ( $current_id ) {
+				$order_item['order_item_id'] = $current_id;
+			}
+		}
+
+
+	}
+
+	static function get_id_from_canonical_id( $canonical_id, $id_field = 'order_item_id' ) {
+		return parent::get_id_from_canonical_id( $canonical_id, $id_field );
+	}
+	static function get_core_object_type() {
+		return 'woocommerce_order_item';
+	}
+}
+

--- a/inc/classes/inserter/woocommerce/class-order-item.php
+++ b/inc/classes/inserter/woocommerce/class-order-item.php
@@ -3,7 +3,9 @@
 namespace HMCI\Inserter\Woocommerce;
 
 use HMCI\Inserter\WP\Base;
+use WC_Order_Factory;
 use WC_Order_Item;
+use WC_Order_Item_Product;
 
 /**
  * Woocommerce Order Item inserter - manages inserting order items into the woocommerce_order_items table.
@@ -30,18 +32,16 @@ class Order_Item extends Base {
 	 * @param [] $order_item_meta Order item meta to insert.
 	 * @return WC_Order_Item
 	 */
-	static function insert( $order_id, $order_item, $canonical_id = false, $order_item_meta = [] ) {
+	static function insert( $order_item, $canonical_id = false, $order_item_meta = [] ) {
 
-		$order_item['order_id'] = $order_id;
-
-		if ( empty( $order_item['order_item_id'] ) && $canonical_id ) {
+		if ( $canonical_id ) {
 			$current_id = static::get_id_from_canonical_id( $canonical_id, 'order_item_id' );
 		}
 
 		if ( $current_id ) {
-			$order_item_record = new WC_Order_Item( $current_id );
+			$order_item_record = WC_Order_Factory::get_order_item( $current_id );
 		} else {
-			$order_item_record = new WC_Order_Item();
+			$order_item_record = new WC_Order_Item_Product();
 		}
 
 		$order_item_record->set_props( $order_item );

--- a/inc/classes/inserter/woocommerce/class-order-item.php
+++ b/inc/classes/inserter/woocommerce/class-order-item.php
@@ -3,6 +3,7 @@
 namespace HMCI\Inserter\Woocommerce;
 
 use HMCI\Inserter\WP\Base;
+use WC_Order_Item;
 
 /**
  * Woocommerce Order Item inserter - manages inserting order items into the woocommerce_order_items table.
@@ -11,24 +12,55 @@ use HMCI\Inserter\WP\Base;
  */
 class Order_Item extends Base {
 
-	static function insert( $order_item, $canonical_id = false, $order_item_meta = [] ) {
+	/**
+	 * "Insert" an order item.
+	 *
+	 * Note: This is different than most of the HMCI inserter classes in that
+	 * it doesn't actually save anything to the database. This is because the
+	 * WC_Order_Item class doesn't expose any save methods, expecting that the
+	 * actual updates will be saved from the WC_Order class.
+	 *
+	 * As a result, this, method just returns a WC_Order_Item object which can
+	 * be added to a WC_Order. See the Order inserter for an example of its
+	 * use.
+	 *
+	 * @param int $order_id Order ID being created.
+	 * @param [] $order_item Order item data.
+	 * @param string $canonical_id Canonical ID to look up this order with.
+	 * @param [] $order_item_meta Order item meta to insert.
+	 * @return WC_Order_Item
+	 */
+	static function insert( $order_id, $order_item, $canonical_id = false, $order_item_meta = [] ) {
+
+		$order_item['order_id'] = $order_id;
 
 		if ( empty( $order_item['order_item_id'] ) && $canonical_id ) {
 			$current_id = static::get_id_from_canonical_id( $canonical_id, 'order_item_id' );
-
-			if ( $current_id ) {
-				$order_item['order_item_id'] = $current_id;
-			}
 		}
 
+		if ( $current_id ) {
+			$order_item_record = new WC_Order_Item( $current_id );
+		} else {
+			$order_item_record = new WC_Order_Item();
+		}
 
+		$order_item_record->set_props( $order_item );
+
+		if ( $canonical_id ) {
+			$order_item_meta[ static::get_canonical_id_key() ] = $canonical_id;
+		}
+
+		foreach ( $order_item_meta as $key => $value ) {
+			$order_item_record->update_meta_data( $key, $value, null );
+		}
+
+		$order_item_record->apply_changes();
+
+		return $order_item_record;
 	}
 
-	static function get_id_from_canonical_id( $canonical_id, $id_field = 'order_item_id' ) {
-		return parent::get_id_from_canonical_id( $canonical_id, $id_field );
-	}
 	static function get_core_object_type() {
-		return 'woocommerce_order_item';
+		return 'order_item';
 	}
 }
 

--- a/inc/classes/inserter/woocommerce/class-order.php
+++ b/inc/classes/inserter/woocommerce/class-order.php
@@ -53,6 +53,14 @@ class Order extends Base {
 		return $order_id;
 	}
 
+	static function set_canonical_id( $order_id, $canonical_id ) {
+		if ( $order_id === static::get_id_from_canonical_id( $canonical_id, 'order_id' ) ) {
+			return;
+		}
+
+		parent:: set_canonical_id( $order_id, $canonical_id );
+	}
+
 	static function get_core_object_type() {
 		global $wpdb;
 

--- a/inc/classes/inserter/woocommerce/class-order.php
+++ b/inc/classes/inserter/woocommerce/class-order.php
@@ -41,13 +41,12 @@ class Order extends Base {
 		$order_id = $order->get_id();
 
 		foreach ( $products as $product ) {
-			$order_item = Order_Item::insert( $order_id, ...$product );
+			$order_item = Order_Item::insert( ...$product );
 
 			$order->add_item( $order_item );
 		}
 
 		$order->set_created_via( 'import' );
-
 		$order->save();
 
 		static::set_canonical_id( $order_id, $canonical_id );

--- a/inc/classes/inserter/woocommerce/class-order.php
+++ b/inc/classes/inserter/woocommerce/class-order.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace HMCI\Inserter\Woocommerce;
+
+use HMCI\Inserter\WP\Base;
+use WC_Order;
+
+/**
+ * Woocommerce Order inserter - manages inserting orders into the wc_orders table.
+ *
+ * @package HMCI\Inserter\WP
+ */
+class Order extends Base {
+
+	/**
+	 * Insert an order record into the database.
+	 *
+	 * @param [] $order_data All the WooCommerce order fields.
+	 * @param string $canonical_id Canonical ID to use for this order.
+	 * @param [] $order_meta Order meta fields.
+	 * @param [] $products Products to include in the order (see Order_Item class for args).
+	 * @return int|WP_Error ID of successfully imported order.
+	 */
+	static function insert( $order_data, $canonical_id, $order_meta = [], $products = [] ) {
+
+		if ( empty( $order_item['id'] ) && $canonical_id ) {
+			$current_id = static::get_id_from_canonical_id( $canonical_id, 'order_id' );
+
+			if ( $current_id ) {
+				$order = wc_get_order( $current_id );
+			}
+		}
+
+		if ( ! $order || is_wp_error( $order ) ) {
+			$order = new WC_Order();
+		}
+
+		$order->set_props( $order_meta );
+
+		foreach ( $products as $product ) {
+			$order_item = Order_Item::insert( ...$product );
+
+			$order->add_item( $order_item );
+		}
+
+		$order->set_created_by( 'import' );
+
+		return $order->save();
+	}
+
+	static function get_core_object_type() {
+		return 'wc_order';
+	}
+}
+

--- a/inc/classes/inserter/woocommerce/class-product.php
+++ b/inc/classes/inserter/woocommerce/class-product.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace HMCI\Inserter\Woocommerce;
+
+use HMCI\Inserter\WP\Post;
+
+/**
+ * Woocommerce Product inserter - manages inserting products from post_data and meta_data
+ *
+ * @package HMCI\Inserter\WP
+ */
+class Product extends Post {
+
+	/**
+	 * Add product post object to the database, and set meta for it.
+	 *
+	 * @param array $post_data     Post data formatted as it will be saved to the posts table. Should match WP_Post data.
+	 * @param bool  $canonical_id  Use an existing canonical ID.
+	 * @param array $post_meta     Metadata to assign to the post.
+	 * @param array $product_meta  Product meta props - defined WooCommerce values that get saved to wc_product_meta_lookup table.
+	 * @return int|\WP_Error
+	 */
+	static function insert( $post_data = [], $canonical_id = false, $post_meta = [], $product_meta = [] ) {
+
+		if ( empty( $post_data['post_type'] ) ) {
+			$post_data['post_type'] = 'product';
+		}
+
+		$product_id = parent::insert( $post_data, $canonical_id, $post_meta );
+
+		if ( $product_id && ! is_wp_error( $product_id ) {
+
+			$product = new WC_Product_Factory()->get_product( $product_id );
+
+			$product->set_props( $product_meta );
+			$product->save();
+		}
+
+		return $product_id;
+	}
+}

--- a/inc/classes/inserter/woocommerce/class-product.php
+++ b/inc/classes/inserter/woocommerce/class-product.php
@@ -3,6 +3,7 @@
 namespace HMCI\Inserter\Woocommerce;
 
 use HMCI\Inserter\WP\Post;
+use WC_Product_Factory;
 
 /**
  * Woocommerce Product inserter - manages inserting products from post_data and meta_data
@@ -28,7 +29,7 @@ class Product extends Post {
 
 		$product_id = parent::insert( $post_data, $canonical_id, $post_meta );
 
-		if ( $product_id && ! is_wp_error( $product_id ) {
+		if ( $product_id && ! is_wp_error( $product_id ) ) {
 
 			$product = new WC_Product_Factory()->get_product( $product_id );
 

--- a/inc/classes/inserter/woocommerce/class-product.php
+++ b/inc/classes/inserter/woocommerce/class-product.php
@@ -31,7 +31,7 @@ class Product extends Post {
 
 		if ( $product_id && ! is_wp_error( $product_id ) ) {
 
-			$product = new WC_Product_Factory()->get_product( $product_id );
+			$product = ( new WC_Product_Factory() )->get_product( $product_id );
 
 			$product->set_props( $product_meta );
 			$product->save();

--- a/plugin.php
+++ b/plugin.php
@@ -46,6 +46,10 @@ require_once( __DIR__ . '/inc/classes/inserter/wp/class-attachment.php' );
 require_once( __DIR__ . '/inc/classes/inserter/wp/class-term.php' );
 require_once( __DIR__ . '/inc/classes/inserter/wp/class-comment.php' );
 
+require_once( __DIR__ . '/inc/classes/inserter/woocommerce/class-order.php' );
+require_once( __DIR__ . '/inc/classes/inserter/woocommerce/class-order-item.php' );
+require_once( __DIR__ . '/inc/classes/inserter/woocommerce/class-product.php' );
+
 require_once( __DIR__ . '/inc/classes/class-master.php' );
 
 /**


### PR DESCRIPTION
Adds classes for the most common data structures in WooCommerce, for use in migrating arbitrary ecommerce data formats to WooCommerce sites.