### PR TITLE
Register a CLI command per importer

### DIFF
--- a/inc/classes/class-master.php
+++ b/inc/classes/class-master.php
@@ -9,7 +9,7 @@ use function HM\Meta_Lookups\register_lookup;
  *
  * Manages
  * - Getting/setting of importer and validator instances
- * - Initialisation of CLI command instances
+ * - Initialization of CLI command instances
  *
  * @package HMCI
  */
@@ -39,7 +39,7 @@ class Master {
 	/**
 	 * Get the master class instance
 	 *
-	 * @return bool
+	 * @return static
 	 */
 	public static function get_instance() {
 
@@ -70,7 +70,7 @@ class Master {
 	 *
 	 * Returns assoc array of importer ID -> class name
 	 *
-	 * @return array
+	 * @return array<string, class-string>
 	 */
 	public static function get_importers() {
 		return self::$importers;
@@ -153,12 +153,13 @@ class Master {
 	}
 
 	/**
-	 * Initialise WP CLI command
+	 * Initialize WP CLI command
 	 */
 	protected function init_cli() {
-
 		if ( defined( 'WP_CLI' ) && 'WP_CLI' ) {
-			\WP_CLI::add_command( 'hmci',  apply_filters( 'hmci_wp_cli_class_name', __NAMESPACE__ . '\\CLI\\HMCI' ) );
+			$class = apply_filters( 'hmci_wp_cli_class_name', __NAMESPACE__ . '\\CLI\\HMCI' );
+			$class = new $class();
+			$class->register_commands();
 		}
 	}
 

--- a/inc/classes/iterator/class-base.php
+++ b/inc/classes/iterator/class-base.php
@@ -77,7 +77,6 @@ abstract class Base implements Base_Interface {
 	 * @param $items
 	 */
 	public function iterate_items( $items ) {
-
 		foreach ( $items as $item ) {
 
 			$r = $this->iterate_item( $item );
@@ -243,7 +242,7 @@ abstract class Base implements Base_Interface {
 	/**
 	 * Get arguments of iterator when being used for import
 	 *
-	 * @return array
+	 * @return array<string, array{ default: mixed, type: string, description: string }>
 	 */
 	public static function get_importer_args() {
 


### PR DESCRIPTION
Previouly HMCI had a single `import` command, and internally handled all arg validation and registration for each importer. It's a lot cleaner to register a CLI command per importer, so WP CLI can show the correct help, validation etc. This also simplifies the implementation significantly.
