### PR TITLE
Remove items in order on update

### DIFF
--- a/inc/classes/inserter/woocommerce/class-order.php
+++ b/inc/classes/inserter/woocommerce/class-order.php
@@ -40,6 +40,9 @@ class Order extends Base {
 
 		$order_id = $order->get_id();
 
+		// Remove any current items from the order if this order is being updated.
+		$order->remove_order_items();
+
 		foreach ( $products as $product ) {
 			$order_item = Order_Item::insert( ...$product );
 
@@ -58,7 +61,7 @@ class Order extends Base {
 			return;
 		}
 
-		parent:: set_canonical_id( $order_id, $canonical_id );
+		parent::set_canonical_id( $order_id, $canonical_id );
 	}
 
 	static function get_core_object_type() {


### PR DESCRIPTION
We need to remove all the currents items before adding new ones, else any updates to existing items won't propogate, and if you try update an order with _less_ order items, it will only append the new ones.
