### PR TITLE
Insert order meta when inserting a WooCommerce order

### DIFF
--- a/inc/classes/inserter/woocommerce/class-order.php
+++ b/inc/classes/inserter/woocommerce/class-order.php
@@ -52,6 +52,12 @@ class Order extends Base {
 		$order->set_created_via( 'import' );
 		$order->save();
 
+		// Assign order meta to order, if any.
+		foreach ( $order_meta as $meta_key => $meta_value ) {
+			$order->update_meta_data( $meta_key, $meta_value );
+		}
+		$order->save_meta_data();
+
 		static::set_canonical_id( $order_id, $canonical_id );
 		return $order_id;
 	}


### PR DESCRIPTION
#77 added an inserter for WooCommerce orders, with a similar signature to that for core WP objects. However, nothing was actually being done with the order meta parameter. This change fixes that by inserting order meta along with the order.