### PR TITLE
Improve registration of CLI flags

### DIFF
--- a/inc/classes/cli/class-hmci.php
+++ b/inc/classes/cli/class-hmci.php
@@ -45,10 +45,10 @@ class HMCI extends \WP_CLI_Command {
 			$synopsis = [];
 			foreach ( $importer_args as $arg => $data ) {
 				$synopsis[] = [
-					'type' => $data['type'] == 'bool' ? 'flag' : 'assoc',
+					'type' => in_array( $data['type'], array( 'bool', 'boolean' ), true ) ? 'flag' : 'assoc',
 					'name' => $arg,
 					'description' => $data['description'],
-					'optional' => ! empty( $data['default'] ),
+					'optional' => isset( $data['default'] ),
 					'default' => $data['default'],
 				];
 			}


### PR DESCRIPTION
Using `empty()` to detect whether a CLI argument is optional disallows falsy default values. E.g. optional flags that default to false, as with this plugin's core `--resume` and `--disable_intermediate_images` flags.

This PR replaces `empty()` with `isset()`, aligning with the behavior in [`HMCI\Iterator\Base::parse_args()`](https://github.com/humanmade/hm-content-import/blob/main/inc/classes/iterator/class-base.php#L142).

As a bonus, convert both `'bool'` and `'boolean'` argument types to `'flag'`.